### PR TITLE
Support lazy components having more bindings than `make`

### DIFF
--- a/src/App.re
+++ b/src/App.re
@@ -33,7 +33,7 @@ let make = () => {
     </button>
     {state.showPDFPreview
        ? <React.Suspense fallback={<div> "Loading..."->React.string </div>}>
-           <PdfPreviewLazy.Lazy title=greeting />
+           <PdfPreviewLazy title=greeting />
          </React.Suspense>
        : React.null}
   </div>;

--- a/src/LazyImport.re
+++ b/src/LazyImport.re
@@ -1,5 +1,8 @@
-
-[@bs.val] external import: string => 'a = "import";
+[@bs.val]
+external importComponent:
+  ([@bs.ignore] (Js.t('a) => React.element), string) =>
+  Js.Promise.t(Js.t('a) => React.element) =
+  "import";
 
 [@bs.module "react"]
 external lazy_: (unit => Js.Promise.t('a)) => 'a = "lazy";

--- a/src/PdfPreviewLazy.re
+++ b/src/PdfPreviewLazy.re
@@ -1,19 +1,20 @@
 module type T = (module type of PdfPreview);
+
 /*
   Needed for BuckleScript to not import the original component:
   See https://github.com/BuckleScript/bucklescript/issues/3543
  */
-[@bs.val] external component: (module T) = "undefined";
+[@bs.val] external unsafePlaceholder: (module T) = "undefined";
 
-/* Module annotation needed to make sure `make` has the same type as
-   the original component */
-module Lazy: T = {
-  /* Includes `makeProps` at the type level without adding `import` of the original component */
-  include (val component);
-  /* 100% unsafe due to `import` typedef :) but will be unified by the explicit type annotation above */
-  let make = LazyImport.(lazy_(() => import("./PdfPreview.bs")));
-  /* All bindings in the original component have to be added here (`makeProps`
-     is external, so no need). Shallowing them here removes invalid access to
-     undefined[1], undefined[n] in the resulting output */
-  let default = make;
-};
+/* By leveraging the shallow `unsafePlaceholder` definition above,
+   we can use PdfPreview types without requiring the PdfPreview.bs.js file */
+module UnsafePlaceholder = (val unsafePlaceholder);
+
+/* Because makeProps is defined as external, it doesn't lead to `require`
+   statements as BuckleScript is able to inline it in the generated code.
+   Note this won't work for other exported functions or values though! */
+let makeProps = UnsafePlaceholder.makeProps;
+let make =
+  LazyImport.(
+    lazy_(() => importComponent(UnsafePlaceholder.make, "./PdfPreview.bs"))
+  );

--- a/src/PdfPreviewLazy.re
+++ b/src/PdfPreviewLazy.re
@@ -4,7 +4,7 @@ module type T = (module type of PdfPreview);
   Needed for BuckleScript to not import the original component:
   See https://github.com/BuckleScript/bucklescript/issues/3543
  */
-[@bs.val] external unsafePlaceholder: (module T) = "undefined";
+let unsafePlaceholder: module T = [%raw {|{}|}];
 
 /* By leveraging the shallow `unsafePlaceholder` definition above,
    we can use PdfPreview types without requiring the PdfPreview.bs.js file */


### PR DESCRIPTION
Related to #1.

Instead of using `include` to bring in `makeProps` from original component, this approach uses a more "manual" approach that imports the functions explicitly.

This doesn't really solve the issue mentioned in #1 (be able to use other declarations in the original component), but at least is a bit more tight from a typing perspective, so usages of these additional declarations will fail to type check.